### PR TITLE
Upgrade to Django 4.2.24 + allauth updates, Gmail SMTP, and profile CRUD

### DIFF
--- a/fotolio/settings.py
+++ b/fotolio/settings.py
@@ -57,6 +57,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -92,12 +93,16 @@ AUTHENTICATION_BACKENDS = [
 
 SITE_ID = 1
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-ACCOUNT_AUTHENTICATION_METHOD = 'username_email'
-ACCOUNT_EMAIL_REQUIRED = True
+# === allauth (new style) ===
+ACCOUNT_LOGIN_METHODS = {"email", "username"}
+ACCOUNT_SIGNUP_FIELDS = [
+    "email*",
+    "email2*",
+    "username*",
+    "password1*",
+    "password2*",
+]
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
-ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE = True
 ACCOUNT_USERNAME_MIN_LENGTH = 4
 LOGIN_URL = '/accounts/login/'
 LOGIN_REDIRECT_URL = '/'
@@ -159,6 +164,28 @@ STATICFILES_DIRS = (
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
+
+
+# ==========================
+# Authentication Settings
+# ==========================
+LOGIN_REDIRECT_URL = "home"
+LOGOUT_REDIRECT_URL = "home"
+
+# ==========================
+# Email Settings (Gmail)
+# ==========================
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_PORT = 465
+EMAIL_USE_TLS = False
+EMAIL_USE_SSL = True
+EMAIL_HOST_USER = "mamered@gmail.com"
+EMAIL_HOST_PASSWORD = "hepnrqaqbsycwvvr"
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+
+
+
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import render, redirect
 from .forms import ProfileForm
+from django.contrib.auth import logout
 
 @login_required
 def profile_view(request):
@@ -20,3 +21,13 @@ def edit_profile(request):
     else:
         form = ProfileForm(instance=profile)
     return render(request, "profiles/edit.html", {"form": form, "profile": profile})
+
+@login_required
+def delete_profile(request):
+    if request.method == "POST":
+        user = request.user
+        logout(request)
+        user.delete() 
+        messages.success(request, "Your account has been deleted successfully.")
+        return redirect("home")
+    return render(request, "profiles/delete_confirm.html")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,11 @@ cffi==2.0.0
 charset-normalizer==3.4.3
 cryptography==45.0.7
 defusedxml==0.7.1
-Django==3.2.25
-django-allauth==0.50.0
+Django==4.2.24
+django-allauth==65.11.2
 idna==3.10
 oauthlib==3.3.1
+pillow==10.3.0
 pycparser==2.23
 PyJWT==2.10.1
 python-dotenv==1.1.1
@@ -15,5 +16,7 @@ python3-openid==3.2.0
 pytz==2025.2
 requests==2.32.5
 requests-oauthlib==2.0.0
+setuptools==80.9.0
 sqlparse==0.5.3
 urllib3==2.5.0
+wheel==0.45.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -116,9 +116,18 @@
 
     </div>
     </nav>
-
+    
     {% if messages %}
-        <div class="message-container"></div>
+    <div class="container mt-3">
+        {% for message in messages %}
+        <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+            </button>
+        </div>
+        {% endfor %}
+    </div>
     {% endif %}
 
     {% block page_header %}


### PR DESCRIPTION
### Overview
This PR upgrades the project to Django 4.2.24 and applies the necessary updates for django-allauth and email verification.

### Changes
- Upgraded Django to 4.2.24
- Updated django-allauth to use new settings style (ACCOUNT_LOGIN_METHODS, ACCOUNT_SIGNUP_FIELDS)
- Added AccountMiddleware to MIDDLEWARE
- Configured Gmail SMTP backend for real email verification
- Updated base.html to display success/error messages with dismiss button
- Synced requirements.txt with latest installed packages

### Why
These updates are required to ensure compatibility with Django 4.2 and allow real email verification for user signup.

### Next Steps
- Test email verification flow in staging
- Deploy changes and update ALLOWED_HOSTS + domain for production